### PR TITLE
[M1-004] populate data

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,6 +11,9 @@ android {
 }
 
 dependencies {
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.firestore)
+
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.material.icons.extended)
 

--- a/app/src/main/java/com/seno/lazypizza/LazyPizzaApp.kt
+++ b/app/src/main/java/com/seno/lazypizza/LazyPizzaApp.kt
@@ -1,6 +1,8 @@
 package com.seno.lazypizza
 
 import android.app.Application
+import com.seno.products.data.di.productsDataModule
+import com.seno.products.presentation.di.productsPresentationModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -18,6 +20,8 @@ class LazyPizzaApp : Application() {
             androidContext(this@LazyPizzaApp)
             androidLogger()
             modules(
+                productsDataModule,
+                productsPresentationModule
             )
         }
     }

--- a/app/src/main/java/com/seno/lazypizza/MainActivity.kt
+++ b/app/src/main/java/com/seno/lazypizza/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.Text
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.google.firebase.FirebaseApp
 import com.seno.core.presentation.theme.LazyPizzaTheme
 
 class MainActivity : ComponentActivity() {
@@ -13,6 +14,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         installSplashScreen()
         enableEdgeToEdge()
+        FirebaseApp.initializeApp(this)
         setContent {
             LazyPizzaTheme {
                 Text(

--- a/build-logic/convention/src/main/java/AndroidAppConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidAppConventionPlugin.kt
@@ -17,6 +17,7 @@ class AndroidAppConventionPlugin : Plugin<Project> {
                 apply(libs.findPlugin("kotlin.android").get().get().pluginId)
                 apply(libs.findPlugin("kotlin.compose").get().get().pluginId)
                 apply(libs.findPlugin("kotlin.serialization").get().get().pluginId)
+                apply(libs.findPlugin("google.services").get().get().pluginId)
            }
 
             extensions.configure<ApplicationExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.room) apply false
+    alias(libs.plugins.google.services) apply false
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -8,5 +8,4 @@ android {
 
 dependencies {
     implementation(projects.core.domain)
-
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ kotlinx-serialization-json = "1.9.0"
 coreSplashscreen = "1.0.1"
 room = "2.8.1"
 ksp = "2.2.20-2.0.3"
+firebase-bom = "34.3.0"
+google-services = "4.4.2"
 
 # Project versions
 projectAppId = "com.seno.lazypizza"
@@ -25,12 +27,6 @@ projectVersionCode = "1"
 projectMinSdkVersion = "24"
 projectTargetSdkVersion = "36"
 projectCompileSdkVersion = "36"
-coreKtx = "1.17.0"
-junit = "4.13.2"
-junitVersion = "1.3.0"
-espressoCore = "3.7.0"
-appcompat = "1.7.1"
-material = "1.13.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -62,18 +58,15 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
+firebase-firestore = { module = "com.google.firebase:firebase-firestore" }
+
 # Gradle
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 android-tools-common = { group = "com.android.tools", name = "common", version.ref = "androidTools" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "room" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -84,6 +77,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 room = { id = "androidx.room", version.ref = "room" }
+google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
 
 lazypizza-android-application = { id = "lazypizza.android.application", version = "unspesified" }
 lazypizza-jvm-library = { id = "lazypizza.jvm.library", version = "unspesified" }

--- a/products/data/build.gradle.kts
+++ b/products/data/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 }
 
 dependencies {
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.firestore)
+    implementation(libs.timber)
     with(projects) {
         implementation(core.domain)
         implementation(core.data)

--- a/products/data/src/main/java/com/seno/products/data/di/ProductsDataModule.kt
+++ b/products/data/src/main/java/com/seno/products/data/di/ProductsDataModule.kt
@@ -1,0 +1,16 @@
+package com.seno.products.data.di
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.seno.products.data.repository.FirestoreProductRepository
+import com.seno.products.domain.repository.ProductsRepository
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val productsDataModule = module {
+    single {
+        FirebaseFirestore.getInstance()
+    }
+
+    singleOf(::FirestoreProductRepository) bind ProductsRepository::class
+}

--- a/products/data/src/main/java/com/seno/products/data/model/MenuItemEntity.kt
+++ b/products/data/src/main/java/com/seno/products/data/model/MenuItemEntity.kt
@@ -1,0 +1,17 @@
+package com.seno.products.data.model
+
+import com.seno.products.domain.model.MenuItem
+
+data class MenuItemEntity(
+    val name: String = "",
+    val image: String = "",
+    val price: Double = 0.0
+)
+
+fun MenuItemEntity.toMenuItem() = MenuItem(
+    name = name,
+    image = image,
+    price = price
+)
+
+

--- a/products/data/src/main/java/com/seno/products/data/model/PizzaItemEntity.kt
+++ b/products/data/src/main/java/com/seno/products/data/model/PizzaItemEntity.kt
@@ -1,0 +1,17 @@
+package com.seno.products.data.model
+
+import com.seno.products.domain.model.PizzaItem
+
+data class PizzaItemEntity(
+    val name: String = "",
+    val image: String = "",
+    val price: Double = 0.0,
+    val ingredients: List<String> = emptyList()
+)
+
+fun PizzaItemEntity.toPizzaItem() = PizzaItem(
+  name = name,
+  image = image,
+  price = price,
+  ingredients = ingredients
+)

--- a/products/data/src/main/java/com/seno/products/data/repository/FirestoreProductRepository.kt
+++ b/products/data/src/main/java/com/seno/products/data/repository/FirestoreProductRepository.kt
@@ -1,0 +1,59 @@
+package com.seno.products.data.repository
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.seno.products.data.model.MenuItemEntity
+import com.seno.products.data.model.PizzaItemEntity
+import com.seno.products.data.model.toMenuItem
+import com.seno.products.data.model.toPizzaItem
+import com.seno.products.domain.model.MenuItem
+import com.seno.products.domain.model.PizzaItem
+import com.seno.products.domain.repository.ProductsRepository
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+class FirestoreProductRepository(
+    private val db: FirebaseFirestore
+): ProductsRepository {
+    override fun drinks(): Flow<List<MenuItem>> = sectionFlow(DRINKS)
+    override fun sauces(): Flow<List<MenuItem>> = sectionFlow(SAUCES)
+    override fun iceCreams(): Flow<List<MenuItem>> = sectionFlow(ICE_CREAMS)
+    override fun extraToppings(): Flow<List<MenuItem>> = sectionFlow(EXTRA_TOPPINGS)
+    override fun pizzas(): Flow<List<PizzaItem>> = pizzasFlow()
+
+    private fun sectionFlow(collection: String): Flow<List<MenuItem>> = callbackFlow {
+        val listener = db.collection(collection)
+            .addSnapshotListener { snap, err ->
+                if (err != null) {
+                    trySend(emptyList())
+                    return@addSnapshotListener
+                }
+
+                val items = snap?.toObjects(MenuItemEntity::class.java).orEmpty()
+                trySend(items.map { it.toMenuItem() })
+            }
+
+        awaitClose { listener.remove() }
+    }
+
+    private fun pizzasFlow(): Flow<List<PizzaItem>> = callbackFlow {
+        val listener = db.collection(PIZZAS)
+            .addSnapshotListener { snap, err ->
+                if (err != null) {
+                    trySend(emptyList())
+                    return@addSnapshotListener
+                }
+                val items = snap?.toObjects(PizzaItemEntity::class.java).orEmpty()
+                trySend(items.map { it.toPizzaItem() })
+            }
+        awaitClose { listener.remove() }
+    }
+
+    private companion object {
+        const val DRINKS = "drinks"
+        const val SAUCES = "sauces"
+        const val ICE_CREAMS = "ice creams"
+        const val EXTRA_TOPPINGS = "extra_toppings"
+        const val PIZZAS = "pizzas"
+    }
+}

--- a/products/domain/src/main/java/com/seno/products/domain/model/MenuItem.kt
+++ b/products/domain/src/main/java/com/seno/products/domain/model/MenuItem.kt
@@ -1,0 +1,7 @@
+package com.seno.products.domain.model
+
+data class MenuItem(
+    val name: String = "",
+    val image: String = "",
+    val price: Double = 0.0
+)

--- a/products/domain/src/main/java/com/seno/products/domain/model/PizzaItem.kt
+++ b/products/domain/src/main/java/com/seno/products/domain/model/PizzaItem.kt
@@ -1,0 +1,8 @@
+package com.seno.products.domain.model
+
+data class PizzaItem(
+    val name: String = "",
+    val image: String = "",
+    val price: Double = 0.0,
+    val ingredients: List<String> = emptyList()
+)

--- a/products/domain/src/main/java/com/seno/products/domain/repository/ProductsRepository.kt
+++ b/products/domain/src/main/java/com/seno/products/domain/repository/ProductsRepository.kt
@@ -1,0 +1,13 @@
+package com.seno.products.domain.repository
+
+import com.seno.products.domain.model.MenuItem
+import com.seno.products.domain.model.PizzaItem
+import kotlinx.coroutines.flow.Flow
+
+interface ProductsRepository {
+    fun drinks(): Flow<List<MenuItem>>
+    fun sauces(): Flow<List<MenuItem>>
+    fun iceCreams(): Flow<List<MenuItem>>
+    fun extraToppings(): Flow<List<MenuItem>>
+    fun pizzas(): Flow<List<PizzaItem>>
+}

--- a/products/presentation/src/main/java/com/seno/products/presentation/di/ProductsPresentationModule.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/di/ProductsPresentationModule.kt
@@ -1,0 +1,7 @@
+package com.seno.products.presentation.di
+
+import org.koin.dsl.module
+
+val productsPresentationModule = module {
+
+}


### PR DESCRIPTION
feat(products): Integrate Firebase Firestore for product data

Integrates Firebase Firestore as the data source for products.

- Adds `google-services` plugin and Firebase dependencies.
- Initializes Firebase in the `MainActivity`.
- Implements `FirestoreProductRepository` to fetch product categories (pizzas, drinks, sauces, etc.) from Firestore collections.
- Defines data models (`MenuItem`, `PizzaItem`) and corresponding entities for mapping.
- Sets up Koin dependency injection modules for the data and presentation layers of the `products` feature.
- Adds `google-services.json` to `.gitignore`.

-sample products fetch
<img width="3882" height="978" alt="2025-10-06_21-04" src="https://github.com/user-attachments/assets/d0c58c88-155e-4684-8387-76767d3ec525" />
