### PR TITLE
[M1-006] detail screen

### DIFF
--- a/app/src/main/java/com/seno/lazypizza/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/seno/lazypizza/navigation/NavigationRoot.kt
@@ -30,6 +30,10 @@ private fun NavGraphBuilder.mainGraph(navHostController: NavHostController) {
     }
 
     composable<Screen.ProductDetail> {
-        ProductDetailRoot()
+        ProductDetailRoot(
+            onBackClicked = {
+                navHostController.navigateUp()
+            }
+        )
     }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/LazyPizzaDefaultScreen.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/LazyPizzaDefaultScreen.kt
@@ -17,7 +17,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 @Composable
 fun LazyPizzaDefaultScreen(
     modifier: Modifier = Modifier,
-    containerColor: Color = MaterialTheme.colorScheme.surface,
+    containerColor: Color = MaterialTheme.colorScheme.background,
     topAppBar: @Composable () -> Unit = {},
     content: @Composable () -> Unit = {},
 ) {

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/LazyPizzaTopAppBar.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/LazyPizzaTopAppBar.kt
@@ -6,8 +6,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.background
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -27,12 +25,4 @@ fun LazyPizzaTopAppBar(
             containerColor = background,
         )
     )
-}
-
-@Preview
-@Composable
-private fun LazyPizzaTopAppBarPreview() {
-    LazyPizzaTheme {
-        LazyPizzaTopAppBar()
-    }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/PizzaCard.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/PizzaCard.kt
@@ -26,11 +26,13 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.seno.core.presentation.R
+import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.body_1_medium
 import com.seno.core.presentation.theme.body_3_regular
 import com.seno.core.presentation.theme.textPrimary
 import com.seno.core.presentation.theme.textSecondary
 import com.seno.core.presentation.theme.title_1_semiBold
+import com.seno.core.presentation.utils.formatToPrice
 
 @Composable
 fun PizzaCard(
@@ -38,7 +40,7 @@ fun PizzaCard(
     imageUrl: String,
     pizzaName: String,
     pizzaDescription: String,
-    pizzaPrice: String,
+    pizzaPrice: Double,
     onPizzaClick: () -> Unit = {},
 ) {
     Row(
@@ -95,7 +97,7 @@ fun PizzaCard(
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = pizzaPrice,
+                text = "$${pizzaPrice.formatToPrice()}",
                 style = title_1_semiBold.copy(
                     color = textPrimary
                 )
@@ -104,13 +106,15 @@ fun PizzaCard(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-fun PizzaCardPreview() {
-    PizzaCard(
-        imageUrl = "",
-        pizzaName = "Margherita",
-        pizzaDescription = "Tomato sauce, mozzarella, fresh basil, olive oil",
-        pizzaPrice = "$8.99"
-    )
+private fun PizzaCardPreview() {
+    LazyPizzaTheme {
+        PizzaCard(
+            imageUrl = "",
+            pizzaName = "Margherita",
+            pizzaDescription = "Tomato sauce, mozzarella, fresh basil, olive oil",
+            pizzaPrice = 8.00
+        )
+    }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/PrimaryButton.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/PrimaryButton.kt
@@ -1,21 +1,19 @@
 package com.seno.core.presentation.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.primary
 import com.seno.core.presentation.theme.primaryGradient
 import com.seno.core.presentation.theme.textOnPrimary
@@ -31,46 +29,42 @@ fun LazyPizzaPrimaryButton(
         onClick = {
             onClick()
         },
-        modifier = modifier,
+        modifier = modifier
+            .background(
+            brush = Brush.horizontalGradient(
+                colors = primaryGradient,
+                startX = 0f,
+                endX = Float.POSITIVE_INFINITY
+            ),
+            shape = CircleShape
+        )
+            .dropShadow(
+                RoundedCornerShape(20.dp)
+            ) {
+                radius = 10f
+                color = primary
+                spread = 6f
+                alpha = 0.25f
+            },
         colors = ButtonDefaults.buttonColors(
             containerColor = Color.Transparent
         )
     ) {
-        Box(
-            modifier = Modifier
-                .background(
-                    brush = Brush.horizontalGradient(
-                        colors = primaryGradient,
-                        startX = 0f,
-                        endX = Float.POSITIVE_INFINITY
-                    ),
-                    shape = CircleShape
-                )
-                .dropShadow(
-                    RoundedCornerShape(20.dp)
-                ) {
-                    radius = 10f
-                    color = primary
-                    spread = 6f
-                    alpha = 0.25f
-                }
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = buttonText,
-                style = title_3,
-                color = textOnPrimary
-            )
-        }
+        Text(
+            text = buttonText,
+            style = title_3,
+            color = textOnPrimary
+        )
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-fun LazyPizzaPrimaryButtonPreview() {
-    LazyPizzaPrimaryButton(
-        buttonText = "Button",
-        onClick = {},
-    )
+private fun LazyPizzaPrimaryButtonPreview() {
+    LazyPizzaTheme {
+        LazyPizzaPrimaryButton(
+            buttonText = "Button",
+            onClick = {},
+        )
+    }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/ProductCard.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/ProductCard.kt
@@ -1,6 +1,11 @@
 package com.seno.core.presentation.components
 
-import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -33,14 +38,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.seno.core.presentation.R
+import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.body_1_medium
 import com.seno.core.presentation.theme.body_4_regular
 import com.seno.core.presentation.theme.outline50
 import com.seno.core.presentation.theme.textPrimary
 import com.seno.core.presentation.theme.textSecondary
 import com.seno.core.presentation.theme.title_1_semiBold
+import com.seno.core.presentation.utils.formatToPrice
+import java.util.Locale
 
-@SuppressLint("DefaultLocale")
 @Composable
 fun ProductCard(
     modifier: Modifier = Modifier,
@@ -78,7 +85,7 @@ fun ProductCard(
                 ),
             contentScale = ContentScale.Crop
         )
-        
+
         Column(
             modifier = Modifier
                 .fillMaxHeight()
@@ -122,13 +129,15 @@ fun ProductCard(
             Spacer(modifier = Modifier.height(12.dp))
 
             Row(
-                modifier = Modifier.fillMaxWidth().padding(end = 8.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(end = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (quantity == 0) {
                     Text(
-                        text = "$${String.format("%.2f", productPrice)}",
+                        text = "$${productPrice.formatToPrice()}",
                         style = title_1_semiBold.copy(color = textPrimary)
                     )
 
@@ -157,10 +166,18 @@ fun ProductCard(
                             )
                         }
 
-                        Text(
-                            text = quantity.toString(),
-                            style = MaterialTheme.typography.titleLarge,
-                        )
+                        AnimatedContent(
+                            quantity,
+                            transitionSpec = {
+                                slideInVertically { -it } + fadeIn() togetherWith slideOutVertically { it } + fadeOut()
+                            }
+                        ) {
+                            Text(
+                                text = it.toString(),
+                                style = MaterialTheme.typography.titleLarge,
+                            )
+
+                        }
 
                         IconButton(
                             onClick = { quantity++ },
@@ -187,11 +204,23 @@ fun ProductCard(
                         horizontalAlignment = Alignment.End
                     ) {
                         Text(
-                            text = "$${String.format("%.2f", productPrice)}",
+                            text = "$${
+                                String.format(
+                                    Locale.ROOT,
+                                    "%.2f",
+                                    productPrice * quantity
+                                )
+                            }",
                             style = title_1_semiBold.copy(color = textPrimary)
                         )
                         Text(
-                            text = "$quantity x $${String.format("%.2f", productPrice * quantity)}",
+                            text = "$quantity x $${
+                                String.format(
+                                    Locale.ROOT,
+                                    "%.2f",
+                                    productPrice
+                                )
+                            }",
                             style = body_4_regular.copy(textSecondary)
                         )
                     }
@@ -201,12 +230,14 @@ fun ProductCard(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-fun ProductCardPreview() {
-    ProductCard(
-        imageUrl = "",
-        productName = "Mineral Water",
-        productPrice = 1.49
-    )
+private fun ProductCardPreview() {
+    LazyPizzaTheme {
+        ProductCard(
+            imageUrl = "",
+            productName = "Mineral Water",
+            productPrice = 1.49
+        )
+    }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/ProductChip.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/ProductChip.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.background
 import com.seno.core.presentation.theme.body_3_medium
 import com.seno.core.presentation.theme.outline
@@ -26,7 +27,7 @@ fun ProductChip(
     onClick: () -> Unit = {},
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .background(color = background)
             .border(
                 width = 1.dp,
@@ -51,10 +52,12 @@ fun ProductChip(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-fun FilterChipPreview() {
-    ProductChip(
-        chipText = "Pizza"
-    )
+private fun FilterChipPreview() {
+    LazyPizzaTheme {
+        ProductChip(
+            chipText = "Pizza"
+        )
+    }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/SearchBar.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/SearchBar.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.seno.core.presentation.R
+import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.body_1_regular
 import com.seno.core.presentation.theme.textSecondary
 
@@ -40,9 +41,10 @@ fun CustomizableSearchBar(
     var hasFocus by remember { mutableStateOf(false) }
 
     BasicTextField(
-        modifier = Modifier.onFocusChanged { focusState ->
+        modifier = modifier.onFocusChanged { focusState ->
             hasFocus = focusState.isFocused
         },
+        singleLine = true,
         value = query,
         onValueChange = { onQueryChange(it) },
         textStyle = body_1_regular,
@@ -88,11 +90,13 @@ fun CustomizableSearchBar(
     )
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-fun SearchBarPreview() {
-    CustomizableSearchBar(
-        query = "",
-        onQueryChange = {},
-    )
+private fun SearchBarPreview() {
+    LazyPizzaTheme {
+        CustomizableSearchBar(
+            query = "",
+            onQueryChange = {},
+        )
+    }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/SecondaryButton.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/SecondaryButton.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.primary
 import com.seno.core.presentation.theme.primary8
 import com.seno.core.presentation.theme.title_3
@@ -20,6 +21,7 @@ fun LazyPizzaSecondaryButton(
     onClick: () -> Unit
 ) {
     OutlinedButton(
+        modifier = modifier,
         onClick = {
             onClick()
         },
@@ -39,11 +41,13 @@ fun LazyPizzaSecondaryButton(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-fun LazyPizzaSecondaryButtonPreview() {
-    LazyPizzaSecondaryButton(
-        buttonText = "Button",
-        onClick = {},
-    )
+private fun LazyPizzaSecondaryButtonPreview() {
+    LazyPizzaTheme {
+        LazyPizzaSecondaryButton(
+            buttonText = "Button",
+            onClick = {},
+        )
+    }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/ToppingCard.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/ToppingCard.kt
@@ -1,61 +1,61 @@
 package com.seno.core.presentation.components
 
-import android.annotation.SuppressLint
-import androidx.compose.foundation.Image
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.seno.core.presentation.R
+import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.body_3_regular
 import com.seno.core.presentation.theme.outline50
 import com.seno.core.presentation.theme.primary
+import com.seno.core.presentation.theme.primary8
 import com.seno.core.presentation.theme.textPrimary
 import com.seno.core.presentation.theme.textSecondary
 import com.seno.core.presentation.theme.title_2
+import com.seno.core.presentation.utils.formatToPrice
 
-@SuppressLint("DefaultLocale")
 @Composable
 fun ToppingCard(
-    modifier: Modifier = Modifier,
-    painterRes: Painter,
+    imageUrl: String,
     toppingName: String,
-    toppingPrice: Double
+    toppingPrice: Double,
+    quantity: Int,
+    onQuantityPlus: () -> Unit,
+    onQuantityMinus: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    var quantity by remember { mutableIntStateOf(0) }
-
     Column(
         modifier = modifier
-            .padding(16.dp)
             .fillMaxWidth()
-            .clickable { if (quantity == 0) quantity = 1 }
+            .clickable { if (quantity == 0) onQuantityPlus() }
             .border(
                 width = 1.dp,
                 color = if (quantity > 0) primary else outline50,
@@ -64,97 +64,117 @@ fun ToppingCard(
             .background(
                 color = MaterialTheme.colorScheme.surfaceContainerHigh,
                 shape = RoundedCornerShape(12.dp)
-            ),
+            )
+            .padding(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
     ) {
-        Image(
-            painter = painterRes,
-            contentDescription = "Pizza",
+        Box(
             modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-                .size(56.dp)
+                .size(64.dp)
                 .background(
-                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                    shape = CircleShape
-                )
-                .padding(12.dp),
-            contentScale = ContentScale.Crop
-        )
+                    color = primary8.copy(alpha = 0.08f),
+                    shape = RoundedCornerShape(100)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = "Pizza",
+                modifier = Modifier
+                    .size(56.dp),
+                contentScale = ContentScale.Crop
+            )
+        }
 
         Text(
             text = toppingName,
             style = body_3_regular.copy(color = textSecondary)
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
-
-        if (quantity == 0) {
-            Text(
-                text = "$${String.format("%.2f", toppingPrice)}",
-                style = title_2.copy(color = textPrimary)
-            )
-        } else {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                IconButton(
-                    onClick = {
-                        if (quantity > 1) quantity-- else quantity = 0
-                    },
-                    modifier = Modifier
-                        .padding(end = 8.dp)
-                        .border(
-                            width = 1.dp,
-                            color = outline50,
-                            shape = RoundedCornerShape(12.dp)
-                        )
-                        .padding(4.dp)
-                        .size(22.dp)
-                ) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.minus_ic),
-                        contentDescription = "Decrease",
-                        modifier = Modifier.size(16.dp)
-                    )
-                }
-
+        Box(
+            modifier = Modifier
+                .height(36.dp)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            if (quantity == 0) {
                 Text(
-                    text = quantity.toString(),
-                    style = MaterialTheme.typography.titleLarge,
+                    text = "$${toppingPrice.formatToPrice()}",
+                    style = title_2.copy(color = textPrimary)
                 )
-
-                IconButton(
-                    onClick = { quantity++ },
-                    modifier = Modifier
-                        .padding(start = 8.dp)
-                        .border(
-                            width = 1.dp,
-                            color = outline50,
-                            shape = RoundedCornerShape(12.dp)
-                        )
-                        .padding(4.dp)
-                        .size(22.dp)
+            } else {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.plus_ic),
-                        contentDescription = "Increase",
-                        modifier = Modifier.size(22.dp)
-                    )
+                    IconButton(
+                        onClick = { onQuantityMinus() },
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .border(
+                                width = 1.dp,
+                                color = outline50,
+                                shape = RoundedCornerShape(12.dp)
+                            )
+                            .padding(4.dp)
+                            .size(22.dp)
+                    ) {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.minus_ic),
+                            contentDescription = "Decrease",
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+
+                    AnimatedContent(
+                        quantity,
+                        transitionSpec = {
+                            slideInVertically { -it } + fadeIn() togetherWith slideOutVertically { it } + fadeOut()
+                        }
+                    ) {
+                        Text(
+                            text = it.toString(),
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    }
+
+                    IconButton(
+                        onClick = { onQuantityPlus() },
+                        modifier = Modifier
+                            .padding(start = 8.dp)
+                            .border(
+                                width = 1.dp,
+                                color = outline50,
+                                shape = RoundedCornerShape(12.dp)
+                            )
+                            .padding(4.dp)
+                            .size(22.dp)
+                    ) {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.plus_ic),
+                            contentDescription = "Increase",
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
                 }
             }
         }
-        Spacer(modifier = Modifier.height(12.dp))
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-fun ToppingCardPreview() {
-    ToppingCard(
-        painterRes = painterResource(id = R.drawable.trash_ic),
-        toppingName = "Sauce",
-        toppingPrice = 1.00
-    )
+private fun ToppingCardPreview() {
+    LazyPizzaTheme {
+        ToppingCard(
+            imageUrl = "",
+            toppingName = "Sauce",
+            toppingPrice = 1.00,
+            quantity = 1,
+            onQuantityPlus = {},
+            onQuantityMinus = {}
+        )
+    }
 }

--- a/core/presentation/src/main/java/com/seno/core/presentation/utils/Extension.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/utils/Extension.kt
@@ -2,6 +2,7 @@ package com.seno.core.presentation.utils
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import java.util.Locale
 
 @Composable
 fun Modifier.applyIf(condition: Boolean, modifier: @Composable Modifier.() -> Modifier): Modifier {
@@ -21,3 +22,7 @@ fun String.toCamelCase() =
         .filter { it.isNotEmpty() }.joinToString(" ") { word ->
             word.replaceFirstChar { it.uppercase() }
         }
+
+fun Double.formatToPrice(): String {
+    return String.format(Locale.ROOT, "%.2f", this)
+}

--- a/products/presentation/build.gradle.kts
+++ b/products/presentation/build.gradle.kts
@@ -8,6 +8,7 @@ android {
 
 dependencies {
     implementation(libs.timber)
+    implementation(libs.coil.compose)
 
     with(projects) {
         implementation(core.presentation)

--- a/products/presentation/src/main/java/com/seno/products/presentation/allproducts/AllProductsScreen.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/allproducts/AllProductsScreen.kt
@@ -5,11 +5,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -17,26 +21,15 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -185,6 +178,9 @@ fun AllProductsScreen(
                 }
             } else {
                 LazyColumn(
+                    contentPadding = PaddingValues(
+                        bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                    ),
                     state = listState,
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
@@ -224,7 +220,7 @@ fun AllProductsScreen(
                                                     pizzaDescription = product.ingredients.joinToString(
                                                         ", "
                                                     ),
-                                                    pizzaPrice = product.price.toString(),
+                                                    pizzaPrice = product.price,
                                                     onPizzaClick = {
                                                         onAction(AllProductsAction.OnProductClicked(pizzaName = product.name))
                                                     }

--- a/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailAction.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailAction.kt
@@ -1,3 +1,6 @@
 package com.seno.products.presentation.detail
 
-sealed interface ProductDetailAction
+sealed interface ProductDetailAction {
+    data class OnToppingPlus(val toppingsUI: ToppingsUI): ProductDetailAction
+    data class OnToppingMinus(val toppingsUI: ToppingsUI): ProductDetailAction
+}

--- a/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailRoot.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailRoot.kt
@@ -1,23 +1,68 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.seno.products.presentation.detail
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.seno.core.presentation.components.LazyPizzaDefaultScreen
+import com.seno.core.presentation.theme.textSecondary
+import com.seno.core.presentation.theme.textSecondary8
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun ProductDetailRoot(
-    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit,
     viewModel: ProductDetailViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    LazyPizzaDefaultScreen {
+    LazyPizzaDefaultScreen(
+        containerColor = MaterialTheme.colorScheme.background,
+        topAppBar = {
+            TopAppBar(
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background
+                ),
+                title = {},
+                navigationIcon = {
+                    IconButton(
+                        modifier = Modifier
+                            .padding(start = 16.dp)
+                            .size(32.dp)
+                            .background(
+                                color = textSecondary8.copy(alpha = 0.08f),
+                                shape = RoundedCornerShape(100)
+                            ),
+                        onClick = { onBackClicked() }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                            contentDescription = "back",
+                            tint = textSecondary
+                        )
+                    }
+                }
+            )
+        }
+    ) {
         ProductDetailScreen(
             state = state,
-            onAction = {}
+            onAction = viewModel::onAction
         )
     }
 }

--- a/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailScreen.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailScreen.kt
@@ -1,19 +1,41 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.seno.products.presentation.detail
 
-import androidx.compose.material3.Text
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.seno.core.presentation.theme.LazyPizzaTheme
+import com.seno.core.presentation.utils.DeviceConfiguration
+import com.seno.products.presentation.detail.component.ProductDetailMobile
+import com.seno.products.presentation.detail.component.ProductDetailTablet
 
 @Composable
-fun ProductDetailScreen(
+internal fun ProductDetailScreen(
     state: ProductDetailState = ProductDetailState(),
     onAction: (ProductDetailAction) -> Unit = {},
 ) {
-    Text("Product detail")
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val deviceType = DeviceConfiguration.fromWindowSizeClass(windowSizeClass)
+
+    if (deviceType.isTablet()) {
+        ProductDetailTablet(
+            state = state,
+            onAction = onAction
+        )
+    } else {
+        ProductDetailMobile(
+            state = state,
+            onAction = onAction
+        )
+    }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ProductDetailScreenPreview() {
-    ProductDetailScreen()
+    LazyPizzaTheme {
+        ProductDetailScreen()
+    }
 }

--- a/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailState.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailState.kt
@@ -1,5 +1,16 @@
 package com.seno.products.presentation.detail
 
+import com.seno.products.domain.model.Product
+
 data class ProductDetailState(
     val isLoading: Boolean = false,
+    val selectedPizza: Product.Pizza? = null,
+    val listExtraToppings: List<ToppingsUI> = emptyList(),
+)
+
+data class ToppingsUI(
+    val name: String,
+    val image: String,
+    val price: Double,
+    val quantity: Int
 )

--- a/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailViewModel.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/detail/ProductDetailViewModel.kt
@@ -2,17 +2,100 @@ package com.seno.products.presentation.detail
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.seno.products.domain.repository.ProductsRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.update
 
 class ProductDetailViewModel(
-    private val savedStateHandle: SavedStateHandle
-): ViewModel() {
+    savedStateHandle: SavedStateHandle,
+    productsRepository: ProductsRepository
+) : ViewModel() {
 
     private val pizzaName = savedStateHandle.get<String>(PIZZA_NAME) ?: ""
 
     private val _state = MutableStateFlow(ProductDetailState())
     val state = _state.asStateFlow()
+
+    init {
+        combine(
+            productsRepository.getPizzaByName(pizzaName),
+            productsRepository.getExtraToppingsFlow()
+        ) { pizza, toppings ->
+            _state.update {
+                it.copy(
+                    selectedPizza = pizza,
+                    listExtraToppings = toppings.map { product ->
+                        ToppingsUI(
+                            name = product.name,
+                            image = product.image,
+                            price = product.price,
+                            quantity = 0
+                        )
+                    }
+                )
+            }
+        }
+            .flowOn(Dispatchers.Default)
+            .launchIn(viewModelScope)
+    }
+
+    fun onAction(action: ProductDetailAction) {
+        when (action) {
+            is ProductDetailAction.OnToppingPlus -> onToppingPlus(action.toppingsUI)
+            is ProductDetailAction.OnToppingMinus -> onToppingMinus(action.toppingsUI)
+        }
+    }
+
+    fun onToppingPlus(toppingsUI: ToppingsUI) {
+        val updatedTopping = _state.value.listExtraToppings.map {
+            if (it == toppingsUI) {
+                it.copy(quantity = it.quantity + 1)
+            } else {
+                it
+            }
+        }
+        val updatedPizza = _state.value.selectedPizza?.let {
+            it.copy(
+                price = it.price + toppingsUI.price
+            )
+        }
+
+        _state.update {
+            it.copy(
+                selectedPizza = updatedPizza,
+                listExtraToppings = updatedTopping
+            )
+        }
+    }
+
+    fun onToppingMinus(toppingsUI: ToppingsUI) {
+        val updatedTopping = _state.value.listExtraToppings.map {
+            if (it == toppingsUI) {
+                it.copy(quantity = it.quantity - 1)
+            } else {
+                it
+            }
+        }
+
+        val updatedPizza = _state.value.selectedPizza?.let {
+            it.copy(
+                price = it.price - toppingsUI.price
+            )
+        }
+
+        _state.update {
+            it.copy(
+                selectedPizza = updatedPizza,
+                listExtraToppings = updatedTopping
+            )
+        }
+    }
 
     companion object {
         private const val PIZZA_NAME = "pizzaName"

--- a/products/presentation/src/main/java/com/seno/products/presentation/detail/component/ProductDetailMobile.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/detail/component/ProductDetailMobile.kt
@@ -1,0 +1,219 @@
+package com.seno.products.presentation.detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.seno.core.presentation.R
+import com.seno.core.presentation.components.LazyPizzaPrimaryButton
+import com.seno.core.presentation.components.ToppingCard
+import com.seno.core.presentation.theme.LazyPizzaTheme
+import com.seno.core.presentation.theme.background
+import com.seno.core.presentation.theme.body_3_regular
+import com.seno.core.presentation.theme.label_2_semiBold
+import com.seno.core.presentation.theme.textPrimary
+import com.seno.core.presentation.theme.textSecondary
+import com.seno.core.presentation.theme.title_1_semiBold
+import com.seno.core.presentation.utils.formatToPrice
+import com.seno.products.domain.model.Product
+import com.seno.products.presentation.detail.ProductDetailAction
+import com.seno.products.presentation.detail.ProductDetailState
+
+@Composable
+internal fun ProductDetailMobile(
+    state: ProductDetailState,
+    onAction: (ProductDetailAction) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var buttonHeight by remember {
+        mutableStateOf(0.dp)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(
+                    RoundedCornerShape(
+                        bottomEnd = 16.dp
+                    )
+                )
+                .background(
+                    color = MaterialTheme.colorScheme.background,
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            state.selectedPizza?.let {
+                AsyncImage(
+                    model = ImageRequest.Builder(context = LocalContext.current)
+                        .data(state.selectedPizza.image)
+                        .crossfade(true)
+                        .build(),
+                    error = painterResource(id = R.drawable.ic_broken_image),
+                    placeholder = painterResource(id = R.drawable.loading_img),
+                    contentDescription = "Pizza",
+                    modifier = Modifier
+                        .wrapContentSize()
+                        .size(240.dp),
+                    contentScale = ContentScale.Crop
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .drawBehind {
+                    drawRect(
+                        color = background,
+                        size = Size(
+                            width = 100.dp.toPx(),
+                            height = 50.dp.toPx()
+                        )
+                    )
+                }
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 16.dp
+                    )
+                )
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .padding(horizontal = 16.dp, vertical = 20.dp)
+        ) {
+            Text(
+                text = state.selectedPizza?.name.orEmpty(),
+                style = title_1_semiBold,
+                color = textPrimary
+            )
+
+            Text(
+                text = state.selectedPizza?.ingredients.orEmpty().joinToString(", "),
+                style = body_3_regular,
+                color = textSecondary,
+            )
+
+            Text(
+                modifier = Modifier
+                    .padding(top = 8.dp),
+                text = stringResource(com.seno.products.presentation.R.string.add_extra_toppings),
+                style = label_2_semiBold,
+                color = textSecondary
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                LazyVerticalGrid(
+                    contentPadding = PaddingValues(top = 8.dp, bottom = buttonHeight / 2),
+                    columns = GridCells.Fixed(3),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(
+                        items = state.listExtraToppings,
+                        key = { it.name }
+                    ) { topping ->
+                        ToppingCard(
+                            imageUrl = topping.image,
+                            toppingName = topping.name,
+                            toppingPrice = topping.price,
+                            quantity = topping.quantity,
+                            onQuantityPlus = {
+                                onAction(ProductDetailAction.OnToppingPlus(topping))
+                            },
+                            onQuantityMinus = {
+                                onAction(ProductDetailAction.OnToppingMinus(topping))
+                            }
+                        )
+                    }
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.BottomCenter)
+                        .height(125.dp)
+                        .background(
+                            brush = Brush.verticalGradient(
+                                colors = listOf(
+                                    MaterialTheme.colorScheme.surface.copy(alpha = 0f),
+                                    MaterialTheme.colorScheme.surface
+                                ),
+                            )
+                        ),
+                    contentAlignment = Alignment.BottomCenter
+                ) {
+                    LazyPizzaPrimaryButton(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .onGloballyPositioned {
+                                buttonHeight = it.size.height.dp
+                            },
+                        onClick = {
+
+                        },
+                        buttonText = "Add to Cart for $${state.selectedPizza?.price?.formatToPrice()}"
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProductDetailMobilePreview() {
+    LazyPizzaTheme {
+        ProductDetailMobile(
+            state = ProductDetailState(
+                selectedPizza = Product.Pizza(
+                    name = "Margherita",
+                    price = 8.00,
+                    image = "",
+                    ingredients = listOf(
+                        "Tomato sauce",
+                        "Mozzarella",
+                        "Basil"
+                    )
+                )
+            ),
+            onAction = {}
+        )
+    }
+}

--- a/products/presentation/src/main/java/com/seno/products/presentation/detail/component/ProductDetailTablet.kt
+++ b/products/presentation/src/main/java/com/seno/products/presentation/detail/component/ProductDetailTablet.kt
@@ -1,0 +1,196 @@
+package com.seno.products.presentation.detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.seno.core.presentation.R
+import com.seno.core.presentation.components.LazyPizzaPrimaryButton
+import com.seno.core.presentation.components.ToppingCard
+import com.seno.core.presentation.theme.LazyPizzaTheme
+import com.seno.core.presentation.theme.body_3_regular
+import com.seno.core.presentation.theme.label_2_semiBold
+import com.seno.core.presentation.theme.textPrimary
+import com.seno.core.presentation.theme.textSecondary
+import com.seno.core.presentation.theme.title_1_semiBold
+import com.seno.core.presentation.utils.DeviceConfiguration
+import com.seno.core.presentation.utils.applyIf
+import com.seno.core.presentation.utils.formatToPrice
+import com.seno.products.presentation.detail.ProductDetailAction
+import com.seno.products.presentation.detail.ProductDetailState
+
+@Composable
+internal fun ProductDetailTablet(
+    state: ProductDetailState,
+    onAction: (ProductDetailAction) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val deviceType = DeviceConfiguration.fromWindowSizeClass(windowSizeClass)
+
+    Row(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .weight(1f)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(
+                        RoundedCornerShape(
+                            bottomEnd = 16.dp
+                        )
+                    )
+                    .background(
+                        color = MaterialTheme.colorScheme.background,
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                state.selectedPizza?.let {
+                    AsyncImage(
+                        model = ImageRequest.Builder(context = LocalContext.current)
+                            .data(state.selectedPizza.image)
+                            .crossfade(true)
+                            .build(),
+                        error = painterResource(id = R.drawable.ic_broken_image),
+                        placeholder = painterResource(id = R.drawable.loading_img),
+                        contentDescription = "Pizza",
+                        modifier = Modifier
+                            .wrapContentSize()
+                            .size(240.dp),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+            }
+
+            Text(
+                text = state.selectedPizza?.name.orEmpty(),
+                style = title_1_semiBold,
+                color = textPrimary
+            )
+
+            Text(
+                text = state.selectedPizza?.ingredients.orEmpty().joinToString(", "),
+                style = body_3_regular,
+                color = textSecondary,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 16.dp,
+                        bottomStart = 16.dp
+                    )
+                )
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .padding(horizontal = 16.dp, vertical = 16.dp)
+                .applyIf(deviceType == DeviceConfiguration.TABLET_LANDSCAPE) {
+                    padding(
+                        bottom = WindowInsets.navigationBars.asPaddingValues()
+                            .calculateBottomPadding()
+                    )
+                },
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(top = 8.dp),
+                text = stringResource(com.seno.products.presentation.R.string.add_extra_toppings),
+                style = label_2_semiBold,
+                color = textSecondary
+            )
+
+            LazyVerticalGrid(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .applyIf(deviceType == DeviceConfiguration.TABLET_LANDSCAPE) {
+                        weight(1f)
+                    },
+                contentPadding = PaddingValues(
+                    top = 8.dp,
+                ),
+                columns = GridCells.Fixed(3),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(
+                    items = state.listExtraToppings,
+                    key = { it.name }
+                ) { topping ->
+                    ToppingCard(
+                        imageUrl = topping.image,
+                        toppingName = topping.name,
+                        toppingPrice = topping.price,
+                        quantity = topping.quantity,
+                        onQuantityPlus = {
+                            onAction(ProductDetailAction.OnToppingPlus(topping))
+                        },
+                        onQuantityMinus = {
+                            onAction(ProductDetailAction.OnToppingMinus(topping))
+                        }
+                    )
+                }
+            }
+
+            LazyPizzaPrimaryButton(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                onClick = {
+
+                },
+                buttonText = "Add to Cart for $${state.selectedPizza?.price?.formatToPrice()}"
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProductDetailTabletPreview() {
+    LazyPizzaTheme {
+        ProductDetailTablet(
+            state = ProductDetailState(),
+            onAction = {}
+        )
+    }
+}

--- a/products/presentation/src/main/res/values/strings.xml
+++ b/products/presentation/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="add_extra_toppings">ADD EXTRA TOPPINGS</string>
+</resources>


### PR DESCRIPTION
feat(product): Implement product detail screen

This commit introduces the product detail screen with responsive layouts for both mobile and tablet devices.

Key changes:
- Created `ProductDetailScreen` which adapts its layout based on the device's screen size (mobile vs. tablet).
- Implemented `ProductDetailMobile` and `ProductDetailTablet` composables for the respective device layouts.
- Developed the `ProductDetailViewModel` to manage the screen's state, including fetching pizza details and available toppings.
- Added logic to handle quantity changes for extra toppings, dynamically updating the total price.
- Refactored `ToppingCard`, `ProductCard`, and `PizzaCard` to be stateless and use a new `formatToPrice` extension function for consistent currency display.
- Added animations to quantity counters in `ProductCard` and `ToppingCard` for a better user experience.
- Implemented a back navigation button in the `ProductDetailRoot`.
- Standardized composable previews to use `LazyPizzaTheme`.

[Mobile]
<img width="1080" height="2400" alt="Screenshot_1760254216" src="https://github.com/user-attachments/assets/46474a0c-b3ab-4bac-8333-263e0efe4d47" />
[Landscape]
<img width="1200" height="1920" alt="Screenshot_1760254525" src="https://github.com/user-attachments/assets/34bbb865-d539-4e62-aeb7-a3fd01fbd971" />