### PR TITLE
[M3-002] Auth Backend

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ ktlint_standard_class-signature = disabled # newline expected after opening/clos
 ktlint_standard_function-naming = disabled # camelCase naming function will warn composable
 ktlint_standard_multiline-expression-wrapping = disabled # multiline expression
 ktlint_standard_trailing-comma-on-declaration-site = disabled # traling comma before ";"
+ktlint_standard_package-name = disabled # package name with underscore
 ktlint_standard_no-wildcard-imports = disabled # wildcard import
 ktlint_compose_modifier-missing-check = disabled # default modifier
 # ktlint_standard_trailing-comma-on-call-site = disabled # traling comma before ")"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     with(projects) {
         with(auth) {
             implementation(data)
+            implementation(domain)
             implementation(presentation)
         }
         with(core) {

--- a/auth/data/build.gradle.kts
+++ b/auth/data/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
         implementation(core.domain)
         implementation(core.data)
     }
-
+    implementation(libs.bundles.ktor)
     implementation(libs.timber)
     implementation(libs.com.googlecode.libphonenumber)
 }

--- a/auth/data/src/main/java/com/seno/auth/data/di/AuthDataModule.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/di/AuthDataModule.kt
@@ -1,11 +1,16 @@
 package com.seno.auth.data.di
 
 import com.seno.auth.data.PhoneValidatorImpl
+import com.seno.auth.data.network.HttpClientFactory
+import com.seno.auth.data.repository.KtorAuthService
 import com.seno.auth.domain.PhoneValidator
+import com.seno.auth.domain.repository.AuthService
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val authDataModule = module {
     singleOf(::PhoneValidatorImpl) bind PhoneValidator::class
+    single { HttpClientFactory().build() }
+    singleOf(::KtorAuthService) bind AuthService::class
 }

--- a/auth/data/src/main/java/com/seno/auth/data/network/HttpClientExt.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/network/HttpClientExt.kt
@@ -1,0 +1,88 @@
+package com.seno.auth.data.network
+
+import com.seno.auth.data.BuildConfig
+import com.seno.core.domain.DataError
+import com.seno.core.domain.Result
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import io.ktor.client.statement.HttpResponse
+import io.ktor.util.network.UnresolvedAddressException
+import kotlinx.serialization.SerializationException
+import java.net.SocketException
+import java.net.UnknownHostException
+import kotlin.coroutines.cancellation.CancellationException
+
+suspend inline fun <reified Response : Any> HttpClient.get(
+    route: String,
+    queryParameter: Map<String, Any?> = mapOf()
+): Result<Response, DataError.Network> =
+    safeCall {
+        get {
+            url(constructRoute(route))
+            queryParameter.forEach { (key, value) ->
+                parameter(key, value)
+            }
+        }
+    }
+
+suspend inline fun <reified Request, reified Response : Any> HttpClient.post(
+    route: String,
+    body: Request,
+    configure: HttpRequestBuilder.() -> Unit = {}
+): Result<Response, DataError.Network> =
+    safeCall {
+        post {
+            url(constructRoute(route))
+            setBody(body)
+            configure()
+        }
+    }
+
+suspend inline fun <reified T> safeCall(execute: () -> HttpResponse): Result<T, DataError.Network> {
+    val response = try {
+        execute()
+    } catch (e: UnresolvedAddressException) {
+        e.printStackTrace()
+        return Result.Error(DataError.Network.NO_INTERNET)
+    } catch (e: UnknownHostException) {
+        e.printStackTrace()
+        return Result.Error(DataError.Network.NO_INTERNET)
+    } catch (e: SerializationException) {
+        e.printStackTrace()
+        return Result.Error(DataError.Network.SERIALIZATION)
+    } catch (e: SocketException) {
+        e.printStackTrace()
+        return Result.Error(DataError.Network.NO_INTERNET)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        e.printStackTrace()
+        return Result.Error(DataError.Network.UNKNOWN)
+    }
+
+    return responseToResult(response)
+}
+
+suspend inline fun <reified T> responseToResult(response: HttpResponse): Result<T, DataError.Network> =
+    when (response.status.value) {
+        in 200..299 -> Result.Success(response.body<T>())
+        401 -> Result.Error(DataError.Network.UNAUTHORIZED)
+        408 -> Result.Error(DataError.Network.REQUEST_TIMEOUT)
+        409 -> Result.Error(DataError.Network.CONFLICT)
+        413 -> Result.Error(DataError.Network.PAYLOAD_TOO_LARGE)
+        429 -> Result.Error(DataError.Network.TOO_MANY_REQUESTS)
+        in 500..599 -> Result.Error(DataError.Network.SERVER_ERROR)
+        else -> Result.Error(DataError.Network.UNKNOWN)
+    }
+
+fun constructRoute(route: String): String =
+    when {
+        route.contains(BuildConfig.TELEGRAM_BASE_URL) -> route
+        route.startsWith("/") -> BuildConfig.TELEGRAM_BASE_URL + route
+        else -> BuildConfig.TELEGRAM_BASE_URL + "/$route"
+    }

--- a/auth/data/src/main/java/com/seno/auth/data/network/HttpClientFactory.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/network/HttpClientFactory.kt
@@ -1,0 +1,48 @@
+package com.seno.auth.data.network
+
+import com.seno.auth.data.BuildConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.headers
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+class HttpClientFactory() {
+    fun build(): HttpClient =
+        HttpClient(OkHttp) {
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        encodeDefaults = true
+                    },
+                )
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 10000
+            }
+            install(Logging) {
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        Timber.d(message)
+                    }
+                }
+                level = LogLevel.ALL
+            }
+            defaultRequest {
+                contentType(ContentType.Application.Json)
+                headers {
+                    append("Authorization", "Bearer ${BuildConfig.TELEGRAM_API_KEY}")
+                }
+            }
+        }
+}

--- a/auth/data/src/main/java/com/seno/auth/data/network/send_code/SendCodeError.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/network/send_code/SendCodeError.kt
@@ -1,0 +1,6 @@
+package com.seno.auth.data.network.send_code
+
+enum class SendCodeError {
+    BALANCE_NOT_ENOUGH,
+    PHONE_NUMBER_INVALID
+}

--- a/auth/data/src/main/java/com/seno/auth/data/network/send_code/SendCodeRequest.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/network/send_code/SendCodeRequest.kt
@@ -1,0 +1,13 @@
+package com.seno.auth.data.network.send_code
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SendCodeRequest(
+    @SerialName("phone_number")
+    val phoneNumber: String,
+    @SerialName("code_length")
+    val codeLength: Int = 4,
+    val ttl: Int = 60
+)

--- a/auth/data/src/main/java/com/seno/auth/data/network/send_code/SendCodeResponse.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/network/send_code/SendCodeResponse.kt
@@ -1,0 +1,35 @@
+package com.seno.auth.data.network.send_code
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SendCodeResponse(
+    @SerialName("ok")
+    val ok: Boolean,
+    @SerialName("result")
+    val result: Result? = null,
+    val error: String? = null
+)
+
+@Serializable
+data class Result(
+    @SerialName("delivery_status")
+    val deliveryStatus: DeliveryStatus,
+    @SerialName("phone_number")
+    val phoneNumber: String,
+    @SerialName("remaining_balance")
+    val remainingBalance: Int,
+    @SerialName("request_cost")
+    val requestCost: Int,
+    @SerialName("request_id")
+    val requestId: String
+)
+
+@Serializable
+data class DeliveryStatus(
+    @SerialName("status")
+    val status: String,
+    @SerialName("updated_at")
+    val updatedAt: Int
+)

--- a/auth/data/src/main/java/com/seno/auth/data/network/verification_code/VerificationCodeError.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/network/verification_code/VerificationCodeError.kt
@@ -1,0 +1,6 @@
+package com.seno.auth.data.network.verification_code
+
+enum class VerificationCodeError {
+    CODE_INVALID,
+    REQUEST_ID_INVALID,
+}

--- a/auth/data/src/main/java/com/seno/auth/data/network/verification_code/VerificationCodeRequest.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/network/verification_code/VerificationCodeRequest.kt
@@ -1,0 +1,11 @@
+package com.seno.auth.data.network.verification_code
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VerificationCodeRequest(
+    @SerialName("request_id")
+    val requestId: String,
+    val code: String
+)

--- a/auth/data/src/main/java/com/seno/auth/data/network/verification_code/VerificationCodeResponse.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/network/verification_code/VerificationCodeResponse.kt
@@ -1,0 +1,45 @@
+package com.seno.auth.data.network.verification_code
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VerificationCodeResponse(
+    @SerialName("ok")
+    val ok: Boolean,
+    @SerialName("result")
+    val result: Result? = null,
+    val error: String? = null
+)
+
+@Serializable
+data class Result(
+    @SerialName("delivery_status")
+    val deliveryStatus: DeliveryStatus,
+    @SerialName("phone_number")
+    val phoneNumber: String,
+    @SerialName("request_cost")
+    val requestCost: Int,
+    @SerialName("request_id")
+    val requestId: String,
+    @SerialName("verification_status")
+    val verificationStatus: VerificationStatus
+)
+
+@Serializable
+data class DeliveryStatus(
+    @SerialName("status")
+    val status: String,
+    @SerialName("updated_at")
+    val updatedAt: Int
+)
+
+@Serializable
+data class VerificationStatus(
+    @SerialName("code_entered")
+    val codeEntered: String,
+    @SerialName("status")
+    val status: String,
+    @SerialName("updated_at")
+    val updatedAt: Int
+)

--- a/auth/data/src/main/java/com/seno/auth/data/repository/KtorAuthService.kt
+++ b/auth/data/src/main/java/com/seno/auth/data/repository/KtorAuthService.kt
@@ -1,0 +1,71 @@
+package com.seno.auth.data.repository
+
+import com.seno.auth.data.network.post
+import com.seno.auth.data.network.send_code.SendCodeError
+import com.seno.auth.data.network.send_code.SendCodeRequest
+import com.seno.auth.data.network.send_code.SendCodeResponse
+import com.seno.auth.data.network.verification_code.VerificationCodeError
+import com.seno.auth.data.network.verification_code.VerificationCodeRequest
+import com.seno.auth.data.network.verification_code.VerificationCodeResponse
+import com.seno.auth.domain.model.RequestId
+import com.seno.auth.domain.repository.AuthService
+import com.seno.core.domain.DataError
+import com.seno.core.domain.EmptyResult
+import com.seno.core.domain.Result
+import com.seno.core.domain.map
+import io.ktor.client.HttpClient
+
+class KtorAuthService(
+    private val httpClient: HttpClient
+) : AuthService {
+    override suspend fun sendCode(phoneNumber: String): Result<RequestId, DataError.Network> {
+        val result = httpClient.post<SendCodeRequest, SendCodeResponse>(
+            route = "/sendVerificationMessage",
+            body = SendCodeRequest(
+                phoneNumber = phoneNumber,
+            ),
+        )
+
+        return when (result) {
+            is Result.Error -> Result.Error(result.error)
+            is Result.Success -> result.map {
+                it.result?.requestId ?: it.error?.let { error ->
+                    return when (error) {
+                        SendCodeError.PHONE_NUMBER_INVALID.name -> Result.Error(DataError.Network.PHONE_NUMBER_INVALID)
+                        SendCodeError.BALANCE_NOT_ENOUGH.name -> Result.Error(DataError.Network.BALANCE_NOT_ENOUGH)
+                        else -> Result.Error(DataError.Network.SERVER_ERROR)
+                    }
+                } ?: return Result.Error(DataError.Network.SERVER_ERROR)
+            }
+        }
+    }
+
+    override suspend fun verificationCode(
+        requestId: RequestId,
+        code: String
+    ): EmptyResult<DataError.Network> {
+        val result = httpClient.post<VerificationCodeRequest, VerificationCodeResponse>(
+            route = "/checkVerificationStatus",
+            body = VerificationCodeRequest(
+                requestId = requestId,
+                code = code,
+            ),
+        )
+
+        return when (result) {
+            is Result.Error -> Result.Error(result.error)
+            is Result.Success -> result.map {
+                it.error?.let { error ->
+                    return when (error) {
+                        VerificationCodeError.REQUEST_ID_INVALID.name -> Result.Error(DataError.Network.REQUEST_ID_INVALID)
+                        else -> Result.Error(DataError.Network.SERVER_ERROR)
+                    }
+                } ?: it.result?.verificationStatus?.let { verificationStatus ->
+                    if (verificationStatus.status == VerificationCodeError.CODE_INVALID.name.lowercase()) {
+                        return Result.Error(DataError.Network.VERIFICATION_CODE_INVALID)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/auth/domain/src/main/java/com/seno/auth/domain/model/RequestId.kt
+++ b/auth/domain/src/main/java/com/seno/auth/domain/model/RequestId.kt
@@ -1,0 +1,7 @@
+package com.seno.auth.domain.model
+
+/**
+RequestId is string response after `sendCode`
+Needed for the `verificationCode`, can be save in savedStateHandle
+ **/
+typealias RequestId = String

--- a/auth/domain/src/main/java/com/seno/auth/domain/repository/AuthService.kt
+++ b/auth/domain/src/main/java/com/seno/auth/domain/repository/AuthService.kt
@@ -1,0 +1,31 @@
+package com.seno.auth.domain.repository
+
+import com.seno.auth.domain.model.RequestId
+import com.seno.core.domain.DataError
+import com.seno.core.domain.EmptyResult
+import com.seno.core.domain.Result
+
+interface AuthService {
+    /**
+     * Sends a verification code to the provided phone number.
+     *
+     * @param phoneNumber The phone number to send the verification code to.
+     * @return A [Result] containing the [RequestId] on success, which is needed for the `verificationCode` step.
+     * On failure, it returns a [DataError.Network] subtype. This error should be handled in the ViewModel
+     * to show a user-friendly message, for example by using `DataError.asUiText()`.
+     */
+    suspend fun sendCode(phoneNumber: String,): Result<RequestId, DataError.Network>
+
+    /**
+     * Verifies the phone number using the provided code and request ID.
+     *
+     * @param requestId The ID received from the [sendCode] function.
+     * @param code The verification code entered by the user.
+     * @return An [EmptyResult] which is [Result.Success] if the code is valid,
+     * or [Result.Error] with a [DataError.Network] value if it fails.
+     */
+    suspend fun verificationCode(
+        requestId: RequestId,
+        code: String,
+    ): EmptyResult<DataError.Network>
+}

--- a/auth/presentation/src/main/java/com/seno/auth/presentation/login/LoginRoot.kt
+++ b/auth/presentation/src/main/java/com/seno/auth/presentation/login/LoginRoot.kt
@@ -1,6 +1,7 @@
 package com.seno.auth.presentation.login
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,18 +24,22 @@ fun LoginRoot(
     val defaultPadding = when (deviceConfiguration) {
         DeviceConfiguration.MOBILE_PORTRAIT,
         DeviceConfiguration.MOBILE_LANDSCAPE -> 16.dp
+
         else -> 220.dp
     }
 
-    LoginScreen(
-        modifier = Modifier
-            .padding(defaultPadding),
-        state = state,
-        onAction = { action ->
-            when (action) {
-                is LoginAction.OnContinueWithoutSignInClick -> onContinueWithoutSignIn()
-                else -> viewModel.onAction(action)
-            }
-        },
-    )
+    Scaffold {
+        LoginScreen(
+            modifier = Modifier
+                .padding(it)
+                .padding(defaultPadding),
+            state = state,
+            onAction = { action ->
+                when (action) {
+                    is LoginAction.OnContinueWithoutSignInClick -> onContinueWithoutSignIn()
+                    else -> viewModel.onAction(action)
+                }
+            },
+        )
+    }
 }

--- a/build-logic/convention/src/main/java/com/seno/convention/BuildType.kt
+++ b/build-logic/convention/src/main/java/com/seno/convention/BuildType.kt
@@ -17,6 +17,11 @@ internal fun Project.configureBuildTypes(
     localProperties.load(localPropertiesFile.inputStream())
 
     commonExtension.run {
+        defaultConfig {
+            buildConfigField("String", "TELEGRAM_BASE_URL", localProperties.getProperty("telegram_base_url"))
+            buildConfigField("String", "TELEGRAM_API_KEY", localProperties.getProperty("telegram_api_token"))
+        }
+
         buildFeatures {
             buildConfig = true
         }

--- a/core/domain/src/main/java/com/seno/core/domain/DataError.kt
+++ b/core/domain/src/main/java/com/seno/core/domain/DataError.kt
@@ -1,10 +1,30 @@
 package com.seno.core.domain
 
 sealed interface DataError : Error {
-    enum class Network : DataError
+    enum class Network : DataError {
+        BAD_REQUEST,
+        REQUEST_TIMEOUT,
+        UNAUTHORIZED,
+        FORBIDDEN,
+        NOT_FOUND,
+        CONFLICT,
+        TOO_MANY_REQUESTS,
+        NO_INTERNET,
+        PAYLOAD_TOO_LARGE,
+        SERVER_ERROR,
+        SERVICE_UNAVAILABLE,
+        SERIALIZATION,
+        PHONE_NUMBER_INVALID,
+        REQUEST_ID_INVALID,
+        VERIFICATION_CODE_INVALID,
+        BALANCE_NOT_ENOUGH,
+        UNKNOWN
+    }
 
     enum class Local : DataError {
         DISK_FULL,
+        NOT_FOUND,
+        UNKNOWN
     }
 }
 

--- a/core/presentation/src/main/java/com/seno/core/presentation/utils/DataErrorToText.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/utils/DataErrorToText.kt
@@ -1,8 +1,30 @@
 package com.seno.core.presentation.utils
 
 import com.seno.core.domain.DataError
+import com.seno.core.presentation.R
 
+// TODO SET The error message from string resource
 fun DataError.asUiText(): UiText =
     when (this) {
-        else -> UiText.DynamicString("Unknown error")
+        DataError.Local.DISK_FULL -> TODO()
+        DataError.Local.NOT_FOUND -> TODO()
+        DataError.Local.UNKNOWN -> TODO()
+        DataError.Network.BAD_REQUEST -> TODO()
+        DataError.Network.REQUEST_TIMEOUT -> TODO()
+        DataError.Network.UNAUTHORIZED -> TODO()
+        DataError.Network.FORBIDDEN -> TODO()
+        DataError.Network.NOT_FOUND -> TODO()
+        DataError.Network.CONFLICT -> TODO()
+        DataError.Network.TOO_MANY_REQUESTS -> TODO()
+        DataError.Network.NO_INTERNET -> TODO()
+        DataError.Network.PAYLOAD_TOO_LARGE -> TODO()
+        DataError.Network.SERVER_ERROR -> TODO()
+        DataError.Network.SERVICE_UNAVAILABLE -> TODO()
+        DataError.Network.SERIALIZATION -> TODO()
+        DataError.Network.PHONE_NUMBER_INVALID -> TODO()
+        DataError.Network.BALANCE_NOT_ENOUGH -> TODO()
+        DataError.Network.UNKNOWN -> TODO()
+        else -> UiText.StringResource(
+            R.string.error_unknown,
+        )
     }

--- a/core/presentation/src/main/res/values/strings.xml
+++ b/core/presentation/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="confirmation_dialog_title">Are you sure you want to log out?</string>
     <string name="cancel">Cancel</string>
     <string name="logout">Log Out</string>
+    <string name="error_unknown">An unknown error occurred.</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ lifecycleRuntimeKtx = "2.9.4"
 activityCompose = "1.11.0"
 composeBom = "2025.10.01"
 koin = "4.1.1"
+ktor = "3.3.1"
 material3Adaptive = "1.2.0"
 navigationSuite = "1.4.0"
 materialIconsExtended = "1.7.8"
@@ -59,6 +60,12 @@ kotlinx-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-seria
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
+
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
@@ -127,4 +134,11 @@ koin-compose = ["koin-core", "koin-android", "koin-androidx-compose"]
 room = [
     "room-runtime",
     "room-ktx",
+]
+ktor = [
+    "ktor-client-core",
+    "ktor-client-okhttp",
+    "ktor-client-content-negotiation",
+    "ktor-serialization-kotlinx-json",
+    "ktor-client-logging"
 ]

--- a/products/data/src/main/java/com/seno/products/data/repository/FirestoreProductRepository.kt
+++ b/products/data/src/main/java/com/seno/products/data/repository/FirestoreProductRepository.kt
@@ -142,6 +142,21 @@ class FirestoreProductRepository(
             FirebaseResult.Error(exception)
         }
 
+    /**
+     * Logs out the user by deleting their entire shopping cart from Firestore and clearing local user data.
+     *
+     * This function performs the following steps in a single Firestore transaction:
+     * 1. Retrieves the current user's cart ID from local storage.
+     * 2. Fetches all items within the corresponding cart in Firestore.
+     * 3. Deletes all cart item documents.
+     * 4. Deletes the parent cart document.
+     * 5. Clears all user data from the local `UserData` store.
+     *
+     * If any step fails, the entire transaction is rolled back, and an error is returned.
+     *
+     * @return [FirebaseResult.Success] with [Unit] if the cart is successfully deleted and user data is cleared.
+     * @return [FirebaseResult.Error] if the cart ID is not found or if any Firestore operation fails.
+     */
     override suspend fun logoutAndDeleteCart(): FirebaseResult<Unit> {
         return try {
             val cartId = userData.getCartId().first()


### PR DESCRIPTION
[M3-002] Auth Backend

- Added Ktor dependencies and created a dependency bundle.
- Implemented `HttpClientFactory` to configure the Ktor client with default settings, including authorization headers and logging.
- Set up a Ktor-based `AuthRepository` to handle `sendCode` and `verificationCode` network requests.
- Added data classes for API requests and responses (`SendCodeRequest`, `SendCodeResponse`, `VerificationCodeRequest`, `VerificationCodeResponse`).
- Expanded the `DataError` sealed interface to include more specific network error types.
- Integrated Ktor and the repository into the DI graph using Koin.
- Added API base URL and token to `build.gradle.kts` from `local.properties`.

Add to local.properties
```kotlin
telegram_base_url="https://gatewayapi.telegram.org"
telegram_api_token="API_TOKEN"
```
api token can get from
https://gateway.telegram.org/
telegrams api docs
https://core.telegram.org/gateway

Sample success and error response
# RequestOTP
- Success requestOTP
<img width="2884" height="1196" alt="2025-11-09_17-31" src="https://github.com/user-attachments/assets/3c7eb657-0c49-4950-a65b-f2876224dbbb" />
-Error requestOTP for invalid phone number
<img width="1800" height="618" alt="2025-11-09_17-32" src="https://github.com/user-attachments/assets/86cc0bd0-2e1b-4be5-a1ae-c8e501be3043" />
- Error requestOTP for balance not enough [This only trigger when we requestOTP to number other than our linked number to api key (dev account)]
<img width="1802" height="626" alt="2025-11-09_17-32_1" src="https://github.com/user-attachments/assets/1d9cef54-b24a-4a47-bed3-b0c53e3db3e8" />

# VerifOTP
- can return error CODE_INVALID and REQUEST_ID_INVALID