### PR TITLE
[M3-013] Order checkout details, recommended addons and comments

### DIFF
--- a/cart/presentation/src/main/java/com/seno/cart/presentation/cart/CartScreen.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/cart/CartScreen.kt
@@ -181,7 +181,7 @@ private fun TabletCartScreenUI(
                         LazyPizzaPrimaryButton(
                             modifier = Modifier.fillMaxWidth(),
                             buttonText = "Proceed to Checkout (${totalPrice.formatToPrice()})",
-                            onClick = { /* Checkout click */ },
+                            onClick = { onAction(CartActions.OnNavigateToCheckoutClick) },
                         )
                     }
                 }

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/cart/CartViewModel.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/cart/CartViewModel.kt
@@ -3,7 +3,6 @@ package com.seno.cart.presentation.cart
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.seno.cart.domain.CartRepository
-import com.seno.cart.domain.CheckoutRepository
 import com.seno.core.domain.FirebaseResult
 import com.seno.core.domain.cart.identityKey
 import com.seno.core.domain.product.ProductType
@@ -26,7 +25,6 @@ import kotlinx.coroutines.launch
 class CartViewModel(
     private val cartRepository: CartRepository,
     private val coreRepository: CoreRepository,
-    private val checkoutRepository: CheckoutRepository,
     private val userData: UserData
 ) : ViewModel() {
     private val _state = MutableStateFlow(CartState())

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutActions.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutActions.kt
@@ -24,5 +24,7 @@ sealed interface OrderCheckoutActions {
 
     data class OnTimeChanged(val time: LocalTime) : OrderCheckoutActions
 
+    data class OnCommentTextChange(val comment: String) : OrderCheckoutActions
+
     data object OnBackClick : OrderCheckoutActions
 }

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutBottomBar.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutBottomBar.kt
@@ -1,0 +1,110 @@
+package com.seno.cart.presentation.checkout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.seno.core.presentation.components.button.LazyPizzaPrimaryButton
+import com.seno.core.presentation.theme.label_1_medium
+import com.seno.core.presentation.theme.label_1_semiBold
+import com.seno.core.presentation.theme.surfaceHigher
+import com.seno.core.presentation.theme.textPrimary
+import com.seno.core.presentation.theme.textSecondary
+import com.seno.core.presentation.utils.formatToPrice
+
+@Composable
+fun OrderCheckoutBottomBar(
+    isTablet: Boolean = false,
+    totalPrice: Double = 0.0
+) {
+    if (isTablet) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "ORDER TOTAL: ",
+                    style = label_1_medium,
+                    color = textSecondary,
+                )
+
+                Text(
+                    text = "$${totalPrice.formatToPrice()}",
+                    style = label_1_semiBold,
+                    color = textPrimary,
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                LazyPizzaPrimaryButton(
+                    modifier = Modifier
+                        .width(380.dp),
+                    buttonText = "Place order",
+                    onClick = { /* */ },
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    } else {
+        Column(
+            modifier = Modifier
+                .background(surfaceHigher)
+                .padding(horizontal = 16.dp),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+            ) {
+                Text(
+                    text = "ORDER TOTAL:",
+                    style = label_1_medium,
+                    color = textSecondary,
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Text(
+                    text = "$${totalPrice.formatToPrice()}",
+                    style = label_1_semiBold,
+                    color = textPrimary,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            LazyPizzaPrimaryButton(
+                modifier = Modifier.fillMaxWidth(),
+                buttonText = "Place order",
+                onClick = { /* */ },
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun OrderCheckoutMobileBottomBarPreview() {
+    OrderCheckoutBottomBar()
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun OrderCheckoutTabletBottomBarPreview() {
+    OrderCheckoutBottomBar(isTablet = true)
+}

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutRoot.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutRoot.kt
@@ -1,24 +1,41 @@
 package com.seno.cart.presentation.checkout
 
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.seno.cart.presentation.cart.CartViewModel
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun OrderCheckoutRoot(
+    cartViewModel: CartViewModel = koinViewModel(),
     viewModel: OrderCheckoutViewModel = koinViewModel(),
     navigateBack: () -> Unit
 ) {
+    val cartState by cartViewModel.state.collectAsStateWithLifecycle()
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    if (cartState.isUpdatingCart) {
+        Dialog(
+            onDismissRequest = {},
+        ) {
+            CircularProgressIndicator()
+        }
+    }
+
     OrderCheckoutScreen(
+        cartState = cartState,
         state = state,
         onAction = { action ->
             when (action) {
                 OrderCheckoutActions.OnBackClick -> navigateBack()
                 else -> viewModel.onAction(action)
             }
+        },
+        onCartAction = {
+            cartViewModel.onAction(it)
         },
     )
 }

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutScreen.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutScreen.kt
@@ -2,38 +2,104 @@ package com.seno.cart.presentation.checkout
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.seno.cart.presentation.cart.CartActions
+import com.seno.cart.presentation.cart.CartState
+import com.seno.cart.presentation.checkout.components.CommentsUI
 import com.seno.cart.presentation.checkout.components.OrderCheckoutTopBar
+import com.seno.cart.presentation.checkout.components.OrderDetailsUI
 import com.seno.cart.presentation.checkout.components.PickUpTimeUI
+import com.seno.cart.presentation.checkout.components.RecommendedAddOnsUI
 import com.seno.core.presentation.theme.background
+import com.seno.core.presentation.theme.surfaceHigher
+import com.seno.core.presentation.utils.DeviceConfiguration
 
 @Composable
 fun OrderCheckoutScreen(
-    state: OrderCheckoutState,
-    onAction: (OrderCheckoutActions) -> Unit,
+    cartState: CartState = CartState(),
+    state: OrderCheckoutState = OrderCheckoutState(),
+    onAction: (OrderCheckoutActions) -> Unit = {},
+    onCartAction: (CartActions) -> Unit = {}
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(
-                color = background,
-                shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-            ),
-    ) {
-        OrderCheckoutTopBar(onBackClick = { onAction(OrderCheckoutActions.OnBackClick) })
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val deviceType = DeviceConfiguration.fromWindowSizeClass(windowSizeClass)
 
+    val totalPrice =
+        remember(cartState.cartItems) {
+            cartState.cartItems.sumOf { it.price * it.quantity }
+        }
+
+    Scaffold(
+        containerColor = background,
+        topBar = {
+            OrderCheckoutTopBar(
+                modifier = Modifier
+                    .background(
+                        color = surfaceHigher,
+                        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+                    ),
+                onBackClick = { onAction(OrderCheckoutActions.OnBackClick) },
+            )
+        },
+        bottomBar = {
+            OrderCheckoutBottomBar(
+                isTablet = deviceType.isTablet(),
+                totalPrice = totalPrice,
+            )
+        },
+    ) { paddingValues ->
         Column(
             modifier = Modifier
+                .background(surfaceHigher)
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
         ) {
             PickUpTimeUI(
                 state = state,
                 onAction = onAction,
+            )
+
+            val cartItemsChunked = cartState.cartItems.chunked(if (deviceType.isTablet()) 2 else 1)
+
+            OrderDetailsUI(
+                cartItems = cartItemsChunked,
+                onQuantityChange = { reference, quantity ->
+                    onCartAction(
+                        CartActions.OnCartItemQuantityChange(
+                            reference = reference,
+                            quantity = quantity,
+                        ),
+                    )
+                },
+                onDeleteClick = { onCartAction(CartActions.OnDeleteCartItemClick(it)) },
+                isTablet = deviceType.isTablet(),
+            )
+
+            RecommendedAddOnsUI(
+                recommendedItems = cartState.recommendedItems,
+                onQuantityChange = { reference, quantity ->
+                    onCartAction(
+                        CartActions.OnCartItemQuantityChange(
+                            reference = reference,
+                            quantity = quantity,
+                        ),
+                    )
+                },
+            )
+
+            CommentsUI(
+                value = state.comment,
+                onValueChange = { onAction(OrderCheckoutActions.OnCommentTextChange(it)) },
             )
         }
     }

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutState.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutState.kt
@@ -16,5 +16,6 @@ data class OrderCheckoutState(
     val timeValidationError: UiText? = null,
     val minSelectableDateMillis: Long = 0L,
     val displayPickupTime: String = "",
-    val displayScheduleDate: String = "Select Date"
+    val displayScheduleDate: String = "Select Date",
+    val comment: String = "",
 )

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutViewModel.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/OrderCheckoutViewModel.kt
@@ -97,9 +97,12 @@ class OrderCheckoutViewModel : ViewModel() {
         return when {
             selectedTime == null -> selectedDate.format(DateTimeFormatter.ofPattern("dd MMMM"))
             isToday -> selectedTime.format(DateTimeFormatter.ofPattern("HH:mm"))
-            else -> "${selectedDate.format(
-                DateTimeFormatter.ofPattern("MMMM dd"),
-            )}, ${selectedTime.format(DateTimeFormatter.ofPattern("HH:mm"))}"
+            else ->
+                "${
+                    selectedDate.format(
+                        DateTimeFormatter.ofPattern("MMMM dd"),
+                    )
+                }, ${selectedTime.format(DateTimeFormatter.ofPattern("HH:mm"))}"
         }
     }
 
@@ -129,6 +132,7 @@ class OrderCheckoutViewModel : ViewModel() {
                 }
                 updateDisplayStrings()
             }
+
             OrderCheckoutActions.OnScheduleTimeSelected -> {
                 _state.update {
                     it.copy(
@@ -138,12 +142,15 @@ class OrderCheckoutViewModel : ViewModel() {
                 }
                 updateDisplayStrings()
             }
+
             OrderCheckoutActions.OnExpandedOrderDetails -> {
                 _state.update { it.copy(isOrderDetailsExpanded = !it.isOrderDetailsExpanded) }
             }
+
             OrderCheckoutActions.OnDismissDatePicker -> {
                 _state.update { it.copy(showDatePicker = false) }
             }
+
             OrderCheckoutActions.OnDismissTimePicker -> {
                 _state.update {
                     it.copy(
@@ -152,6 +159,7 @@ class OrderCheckoutViewModel : ViewModel() {
                     )
                 }
             }
+
             OrderCheckoutActions.OnCancelTimePicker -> {
                 _state.update {
                     val hasConfirmedTime = it.selectedScheduleTime != null
@@ -165,6 +173,7 @@ class OrderCheckoutViewModel : ViewModel() {
                 }
                 updateDisplayStrings()
             }
+
             OrderCheckoutActions.OnConfirmDatePicker -> {
                 _state.update {
                     it.copy(
@@ -173,6 +182,7 @@ class OrderCheckoutViewModel : ViewModel() {
                     )
                 }
             }
+
             is OrderCheckoutActions.OnDateSelected -> {
                 val dateMillis = action.date
                     .atStartOfDay(ZoneId.systemDefault())
@@ -184,6 +194,7 @@ class OrderCheckoutViewModel : ViewModel() {
                 }
                 updateDisplayStrings()
             }
+
             is OrderCheckoutActions.OnTimeChanged -> {
                 val selectedDate = _state.value.selectedScheduleDateMillis?.let {
                     Instant
@@ -196,6 +207,7 @@ class OrderCheckoutViewModel : ViewModel() {
                     it.copy(timeValidationError = error)
                 }
             }
+
             is OrderCheckoutActions.OnTimeSelected -> {
                 val selectedDate = _state.value.selectedScheduleDateMillis?.let {
                     Instant
@@ -215,6 +227,13 @@ class OrderCheckoutViewModel : ViewModel() {
                     updateDisplayStrings()
                 }
             }
+
+            is OrderCheckoutActions.OnCommentTextChange -> {
+                _state.update {
+                    it.copy(comment = action.comment)
+                }
+            }
+
             else -> Unit
         }
     }

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/components/CommentsUI.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/components/CommentsUI.kt
@@ -1,0 +1,88 @@
+package com.seno.cart.presentation.checkout.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.seno.core.presentation.theme.body_2_regular
+import com.seno.core.presentation.theme.label_2_semiBold
+import com.seno.core.presentation.theme.surfaceHighest
+import com.seno.core.presentation.theme.textPrimary
+import com.seno.core.presentation.theme.textSecondary
+
+@Composable
+fun CommentsUI(
+    value: String,
+    onValueChange: (String) -> Unit = {},
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    Column(
+        modifier = Modifier
+            .padding(top = 16.dp),
+    ) {
+        Text(
+            text = "COMMENTS",
+            style = label_2_semiBold,
+            color = textSecondary,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        BasicTextField(
+            modifier = Modifier
+                .heightIn(min = 92.dp)
+                .fillMaxWidth(),
+            value = value,
+            onValueChange = onValueChange,
+            textStyle = body_2_regular.copy(
+                color = textPrimary,
+            ),
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier = Modifier
+                        .background(
+                            color = surfaceHighest,
+                            shape = RoundedCornerShape(16.dp),
+                        ).padding(
+                            vertical = 13.dp,
+                            horizontal = 20.dp,
+                        ),
+                ) {
+                    if ((isFocused && value.isEmpty()) || (!isFocused && value.isEmpty())) {
+                        Text(
+                            text = "Add Comment",
+                            style = body_2_regular,
+                            color = textSecondary,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CommentsUIPreview() {
+    CommentsUI(value = "")
+}

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/components/OrderDetailsUI.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/components/OrderDetailsUI.kt
@@ -1,0 +1,134 @@
+package com.seno.cart.presentation.checkout.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.seno.core.presentation.components.card.ProductCard
+import com.seno.core.presentation.model.CartItemUI
+import com.seno.core.presentation.theme.label_2_semiBold
+import com.seno.core.presentation.theme.outline
+import com.seno.core.presentation.theme.outline50
+import com.seno.core.presentation.theme.textSecondary
+
+@Composable
+internal fun OrderDetailsUI(
+    onQuantityChange: (String, Int) -> Unit,
+    cartItems: List<List<CartItemUI>> = emptyList(),
+    onDeleteClick: (String) -> Unit = {},
+    isTablet: Boolean = false,
+) {
+    var showDetails by remember { mutableStateOf(false) }
+
+    Column {
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "ORDER DETAILS",
+                style = label_2_semiBold,
+                color = textSecondary,
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Box(
+                modifier = Modifier
+                    .size(22.dp)
+                    .clip(shape = RoundedCornerShape(8.dp))
+                    .border(
+                        width = 1.dp,
+                        shape = RoundedCornerShape(8.dp),
+                        color = outline50,
+                    ).clickable(
+                        enabled = cartItems.isNotEmpty(),
+                        onClick = {
+                            showDetails = !showDetails
+                        },
+                    ),
+            ) {
+                Icon(
+                    imageVector = if (showDetails) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                    tint = textSecondary,
+                    contentDescription = "",
+                )
+            }
+        }
+
+        if (showDetails) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            cartItems.forEach { cartItems ->
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    cartItems.forEach { cartItem ->
+                        ProductCard(
+                            imageUrl = cartItem.image,
+                            productName = cartItem.name,
+                            productPrice = cartItem.price,
+                            quantity = cartItem.quantity,
+                            onQuantityChange = { newQuantity ->
+                                onQuantityChange(
+                                    cartItem.reference,
+                                    newQuantity,
+                                )
+                            },
+                            onDeleteClick = {
+                                onDeleteClick(cartItem.reference)
+                            },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+
+                    if (isTablet && cartItems.size == 1) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        HorizontalDivider(thickness = 1.dp, color = outline)
+    }
+}
+
+@Preview
+@Composable
+private fun OrderDetailsUIPreview() {
+    OrderDetailsUI(
+        cartItems = listOf(),
+        onQuantityChange = { _, _ -> },
+    )
+}

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/components/PickUpTimeUI.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/components/PickUpTimeUI.kt
@@ -32,11 +32,12 @@ internal fun PickUpTimeUI(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp),
+            .padding(top = 8.dp),
     ) {
         Text(
             text = stringResource(R.string.pickup_time),
-            style = label_2_semiBold.copy(color = textSecondary),
+            style = label_2_semiBold,
+            color = textSecondary,
         )
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/components/RecommendedAddOnsUI.kt
+++ b/cart/presentation/src/main/java/com/seno/cart/presentation/checkout/components/RecommendedAddOnsUI.kt
@@ -1,0 +1,72 @@
+package com.seno.cart.presentation.checkout.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.seno.cart.presentation.cart.components.CartToppingCard
+import com.seno.core.presentation.model.CartItemUI
+import com.seno.core.presentation.theme.label_2_semiBold
+import com.seno.core.presentation.theme.outline
+import com.seno.core.presentation.theme.textSecondary
+
+@Composable
+fun RecommendedAddOnsUI(
+    recommendedItems: List<CartItemUI>,
+    onQuantityChange: (String, Int) -> Unit,
+) {
+    Column {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "RECOMMENDED ADD-ONS",
+            style = label_2_semiBold,
+            color = textSecondary,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        LazyRow(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(horizontal = 8.dp),
+        ) {
+            itemsIndexed(recommendedItems) { index, recommendedItem ->
+                CartToppingCard(
+                    imageUrl = recommendedItem.image,
+                    cartItem = recommendedItem,
+                    onClick = {
+                        onQuantityChange(
+                            recommendedItem.reference,
+                            recommendedItem.quantity,
+                        )
+                    },
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        HorizontalDivider(thickness = 1.dp, color = outline)
+    }
+}
+
+@Preview
+@Composable
+private fun RecommendedAddOnsPreview() {
+    RecommendedAddOnsUI(
+        recommendedItems = listOf(),
+        onQuantityChange = { _, _ -> },
+    )
+}

--- a/core/presentation/src/main/java/com/seno/core/presentation/components/bar/NavigationBarItems.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/components/bar/NavigationBarItems.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import com.seno.core.presentation.model.NavigationMenu
 import com.seno.core.presentation.theme.LazyPizzaTheme
 import com.seno.core.presentation.theme.background
-import com.seno.core.presentation.theme.surfaceHigher
 
 @Composable
 fun NavigationBarItems(
@@ -61,7 +60,7 @@ fun NavigationBarItems(
                 }.clip(
                     shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp),
                 ).background(
-                    color = surfaceHigher,
+                    color = background,
                 ).padding(
                     top = 10.dp,
                     bottom = 30.dp,

--- a/core/presentation/src/main/java/com/seno/core/presentation/theme/Type.kt
+++ b/core/presentation/src/main/java/com/seno/core/presentation/theme/Type.kt
@@ -72,6 +72,20 @@ val title_4 =
         fontSize = 12.sp,
         lineHeight = 16.sp,
     )
+val label_1_medium =
+    TextStyle(
+        fontFamily = FontFamily(Font(R.font.instrument_sans_medium)),
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+    )
+val label_1_semiBold =
+    TextStyle(
+        fontFamily = FontFamily(Font(R.font.instrument_sans_semibold)),
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+    )
 val label_2_semiBold =
     TextStyle(
         fontFamily = FontFamily(Font(R.font.instrument_sans_semibold)),


### PR DESCRIPTION
In this task some features for cehckout are implemented:

- Order details
- Recommended addons
- Comments

The main thing of this task is that checkout order screen recieves the cart viewmodel because CheckOutScreen needs the same from logic from cart.

Other things fixed:
- Badge count was not appearing in tablet

<img width="2304" height="1440" alt="Screenshot_20251126_160109" src="https://github.com/user-attachments/assets/9a3a27e6-dcb5-4a75-ab5b-9aaebdc555fd" />

https://github.com/user-attachments/assets/a158c7f5-5b04-45fd-bf6b-fa6efc3aefc6